### PR TITLE
Add install guide

### DIFF
--- a/download/guide.html
+++ b/download/guide.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta property="og:title" content="Glide Client">
+    <meta property="og:description" content="The website for Glide Client">
+    <meta property="og:image" content="../assets/embed.png">
+    <meta property="og:url" content="https://glideclient.github.io">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Glide Client">
+    <meta name="twitter:description" content="The website for Glide Client">
+    <meta name="twitter:image" content="../assets/embed.png">
+    <meta name="description" content="The website for Glide Client">
+    <meta name="keywords" content="minecraft, glide client, Soar client">
+    <meta name="author" content="Glide client">
+    <meta name="theme-color" content="#6603fc">
+    <title>Glide Client - Download</title>
+    <link rel="stylesheet" href="../style.css">
+    <link rel="icon" type="image/svg+xml" href="../assets/logo.svg">
+</head>
+<body>
+    <div class="loader-wrapper">
+        <div class="loader">
+            <img src="../assets/logo.svg" alt="Glide Client Logo">
+        </div>
+    </div>
+
+    <header class="header">
+        <nav class="navbar">
+            <div class="logo">
+                <a href="/">
+                    <img src="../assets/logo.svg" alt="Glide Client Logo">
+                </a>
+            </div>
+            <div class="hamburger">
+                <span></span>
+                <span></span>
+                <span></span>
+            </div>
+            <ul class="nav-links">
+                <li><a href="../#features">Features</a></li>
+                <li><a href="../#about">About</a></li>
+                <li><a href="../download">Download</a></li>
+                <li><a href="../discord">Discord</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main class="main">
+        <section class="hero">
+            <div style="margin-bottom: 10%;">
+                <h1>Install Guide</h1>
+                <p>1. Download the <a href="https://github.com/GlideClient/client/releases/latest">zip file</a> from the Glide Client releases.</p>
+                <p>2. Use WinRAR or the default windows file manager to extract the zip file.</p>
+                <p>3. Press ⊞ + R to open the Run panel, and type <code>%appdata</code> and press enter.</p>
+                <p>4. Head to the <code>.minecraft\versions</code> directory and drop the unzipped folder from earlier into the versions folder.</p>
+                <p>5. Restart the Minecraft Launcher and you should see a Glade Client profile.</
+                <p>Enjoy testing and join the <a href="https://discord.gg/42PXqKvwxq">discord</a> for support and to report bugs!</p>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="footer-content">
+            <p>Website by Glide Client Team</p>
+            <p>GlideClient is not endorsed by <a href="https://github.com/Soar-Client/Legacy-SoarClient">Soar Client</a> nor <a href="https://github.com/EldoDebug">EldoDebug</a></p>
+            <p>Follow us: <a href="https://www.youtube.com/@glideclient" target="_blank">Youtube</a> | <a href="https://github.com/GlideClient/" target="_blank">GitHub</a></p>
+        </div>
+    </footer>
+
+    <script>
+        window.addEventListener('load', () => {
+            const loaderWrapper = document.querySelector('.loader-wrapper');
+            loaderWrapper.classList.add('fade-out');
+        });
+
+        const hamburger = document.querySelector('.hamburger');
+        const navLinks = document.querySelector('.nav-links');
+        
+        hamburger.addEventListener('click', () => {
+            hamburger.classList.toggle('active');
+            navLinks.classList.toggle('active');
+        });
+        
+        document.querySelectorAll('.nav-links a').forEach(link => {
+            link.addEventListener('click', () => {
+                hamburger.classList.remove('active');
+                navLinks.classList.remove('active');
+            });
+        });
+    </script>
+</body>
+</html>

--- a/download/index.html
+++ b/download/index.html
@@ -16,7 +16,7 @@
     <meta name="author" content="Glide client">
     <meta name="theme-color" content="#6603fc">
     <title>Glide Client - Download</title>
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="../style.css">
     <link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
 </head>
 <body>
@@ -53,6 +53,7 @@
             <p>Glide Client is in public beta, expect things to be incomplete</p>
             <div class="button-group">
                 <a href="https://github.com/GlideClient/client/releases/tag/7.2-BETA-1" class="cta-button">Go to the beta download</a>
+                <a href="./guide.html" class="cta-button">Install Guide</a>
             </div>
         </section>
     </main>


### PR DESCRIPTION
Per request of @iamnotrajdip, adds an easier way of seeing how to add Glade Client to the launcher instead of looking at the GitHub repo.